### PR TITLE
Keeping state out of map container

### DIFF
--- a/client/src/components/MapContainer/index.js
+++ b/client/src/components/MapContainer/index.js
@@ -9,14 +9,10 @@ const mapStyles = {
 export class MapContainer extends React.Component {
     constructor(props) {
       super(props);
-  
-      this.state = {
-        stores: props.mapInfo
-      }
     }
 
     displayMarkers = () => {
-      return this.state.stores.map((store, index) => {
+      return this.props.mapInfo.map((store, index) => {
         return <Marker key={index} id={index} position={{
          lat: store.lat,
          lng: store.long

--- a/client/src/pages/Landing.js
+++ b/client/src/pages/Landing.js
@@ -122,9 +122,6 @@ function Landing(props) {
             
             <p>Selected House:</p>
             {renderHouse()}
-            {/* { houseSelected ? 
-              <Link to={"/api/houses/"+currentHouse._id}>Go to House</Link> :
-            <p></p> } */}
            
           </Col>
         </Row>


### PR DESCRIPTION
Keeping the state only in the landing page.  Keeping it out of map container gets rid of rendering issues.